### PR TITLE
Bump to vty 5.26 (make rewrite-inspector build on GHC 8.8)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,7 +17,7 @@ repository head.hackage
              8f79fd2389ab2967354407ec852cbe73f2e8635793ac446d09461ffb99527f6e
   key-threshold: 3
 
-index-state: 2019-07-02T10:28:01Z
+index-state: 2019-10-23T05:10:28Z
 
 -- Build documentation for all dependencies so we can upload docs to hackage
 -- with proper links

--- a/rewrite-inspector.cabal
+++ b/rewrite-inspector.cabal
@@ -1,5 +1,5 @@
 name: rewrite-inspector
-version: 0.1.0.9
+version: 0.1.0.10
 cabal-version: >=1.10
 build-type: Simple
 license: BSD3
@@ -35,7 +35,7 @@ library
                       hashable      >= 1.2.1.0  && < 1.3,
                       containers    >= 0.5.0.0  && < 0.7,
                       brick         == 0.46,
-                      vty           >= 5.23.1,
+                      vty           >= 5.26,
                       prettyprinter >= 1.2.0.1  && < 2.0,
                       text,
                       microlens     >= 0.3.0.0,

--- a/src/BrickUI.hs
+++ b/src/BrickUI.hs
@@ -15,7 +15,7 @@ import Prelude hiding (fail)
 
 import System.Environment     (getArgs)
 import Control.Applicative    ((<|>))
-import Control.Monad          (void, (>>))
+import Control.Monad          (void)
 import Control.Monad.Fail     (MonadFail (..))
 import Control.Monad.IO.Class (liftIO)
 

--- a/src/BrickUI.hs
+++ b/src/BrickUI.hs
@@ -196,7 +196,7 @@ instance MonadFail (EventM Name) where
 lookupSize :: EventM Name (VizStates term -> VizStates term)
 lookupSize = do
   out    <- V.outputIface <$> B.getVtyHandle
-  (w, h) <- V.displayBounds out
+  (w, h) <- liftIO (V.displayBounds out)
   return $ (width .~ w) . (height .~ h)
 
 -- | Update number of occurrences of searched string in both viewports.


### PR DESCRIPTION
`rewrite-inspector` currently doesn't build on GHC 8.8 due to an outdated dependency. This PR ups the version bounds of `vty`. Could you make a new release including this fix @omelkonian :)?